### PR TITLE
Added ~/.azure credentials folder for purge functionality

### DIFF
--- a/docker/job-spec.json.lw-tosca-purge
+++ b/docker/job-spec.json.lw-tosca-purge
@@ -1,7 +1,10 @@
 {
   "required_queues":["system-jobs-queue"],
   "command":"/home/ops/verdi/ops/lightweight-jobs/purge.sh",
-  "imported_worker_files":{"$HOME/.aws":"/home/ops/.aws"},
+  "imported_worker_files":{
+    "$HOME/.aws":"/home/ops/.aws",
+    "$HOME/.azure": "/home/ops/.azure"
+  },
   "disk_usage":"3GB",
   "params" : [
     {


### PR DESCRIPTION
This PR adds the `~/.azure` folder containing Azure credentials into the `job-spec` of `lw-tosca-purge` to fix dataset purge functionality on Azure systems