### PR TITLE
Add exclude field for wget job 

### DIFF
--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -17,7 +17,7 @@
       "name": "glob",
       "type": "text",
       "from": "submitter",
-      "default": "*fn*_logra2a1*.tif,*logamp*.tif,*.dem*,*msk.tif",
+      "default": "N_*fn*_logra2a1.tif,N_*logamp*.tif,*.dem*",N_*_msk.tif",
       "placeholder": "A comma seperated list of globs to download"
     },
     {

--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -17,7 +17,7 @@
       "name": "glob",
       "type": "text",
       "from": "submitter",
-      "default": "*fn*_logra2a1.tif,*logmap*.tif,*.dem*",
+      "default": "*fn*_logra2a1.tif,*logamp*.tif,*.dem*",
       "placeholder": "A comma seperated list of globs to download"
     },
     {

--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -17,7 +17,7 @@
       "name": "glob",
       "type": "text",
       "from": "submitter",
-      "default": "*fn*_logra2a1.tif,*logamp*.tif,*.dem*",
+      "default": "N*fn*_logra2a1.tif,N*logamp*.tif,*.dem*",
       "placeholder": "A comma seperated list of globs to download"
     },
     {

--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -14,11 +14,18 @@
       "from": "submitter"
     },
     {
-      "name": "glob",
+      "name": "include_glob",
       "type": "text",
       "from": "submitter",
-      "default": "N_*fn*_logra2a1.tif,N_*logamp*.tif,*.dem*,N_*_msk.tif",
+      "default": "*final*",
       "placeholder": "A comma seperated list of globs to download"
+    },
+    {
+      "name": "exclude_glob",
+      "type": "text",
+      "from": "submitter",
+      "default": "*tiles*",
+      "placeholder": "A comma seperated list of globs to exclude from included list"
     },
     {
       "name": "name",

--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -17,7 +17,7 @@
       "name": "glob",
       "type": "text",
       "from": "submitter",
-      "default": "*fn*_logra2a1.tif,*logamp*.tif,*.dem*",
+      "default": "*fn*_logra2a1*.tif,*logamp*.tif,*.dem*,*msk.tif",
       "placeholder": "A comma seperated list of globs to download"
     },
     {

--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -1,0 +1,29 @@
+{
+  "label":"Wget Script Glob Select via E-mail",
+  "component":"tosca",
+  "submission_type":"individual",
+  "params" : [
+    {
+      "name": "query",
+      "type": "text",
+      "from": "passthrough"
+    },
+    {
+      "name": "emails",
+      "type": "text",
+      "from": "submitter"
+    },
+    {
+      "name": "glob",
+      "type": "text",
+      "from": "submitter",
+      "default": "*fn*_logra2a1.tif,*logmap*.tif,*.dem*",
+      "placeholder": "A comma seperated list of globs to download"
+    },
+    {
+      "name": "name",
+      "type": "text",
+      "from": "passthrough"
+    }
+  ]
+}

--- a/docker/job-spec.json.lw-tosca-wget-glob
+++ b/docker/job-spec.json.lw-tosca-wget-glob
@@ -1,0 +1,24 @@
+{
+ "required_queues":["system-jobs-queue"],
+ "command":"/home/ops/verdi/ops/lightweight-jobs/wget.sh",
+ "imported_worker_files":{"$HOME/.aws":"/home/ops/.aws"},
+ "disk_usage":"3GB",
+  "params" : [
+    {
+      "name": "query",
+      "destination": "positional"
+    },
+    {
+      "name": "emails",
+      "destination": "positional"
+    },
+    {
+      "name": "name",
+      "destination": "positional"
+    },
+    {
+      "name": "glob",
+      "destination": "context"
+    }
+   ]
+}

--- a/docker/job-spec.json.lw-tosca-wget-glob
+++ b/docker/job-spec.json.lw-tosca-wget-glob
@@ -17,7 +17,11 @@
       "destination": "positional"
     },
     {
-      "name": "glob",
+      "name": "include_glob",
+      "destination": "context"
+    },
+    {
+      "name": "exclude_glob",
       "destination": "context"
     }
    ]

--- a/wget.py
+++ b/wget.py
@@ -194,8 +194,6 @@ def glob_filter(names, glob_dict):
             files.extend(matching)
         print("Got the following files to include: %s" % str(files))
 
-
-    # TODO: continue working from here, we need to find a way to esclude from the current file list
     if exclude_csv:
         pattern_list_exc = [item.strip() for item in exclude_csv.split(',')]
 

--- a/wget.py
+++ b/wget.py
@@ -113,7 +113,7 @@ def wget_script(dataset=None, glob_list=None):
     
     # malarout: interate over each line of stream_wget response, and write to a file which is later attached to the email.
     with open('wget_script.sh','w') as f:
-        for i in stream_wget(scroll_id):
+        for i in stream_wget(scroll_id, glob_list):
                 f.write(i)
 
     # for gzip compressed use file extension .tar.gz and modifier "w:gz"
@@ -187,6 +187,7 @@ def glob_filter(names,pattern):
         files.extend(matching)
     #unique list
     retfiles_set = set(files)
+    print("Got the following files: %s" % str(retfiles_set))
     return list(retfiles_set)
 
 if __name__ == "__main__":
@@ -211,8 +212,9 @@ if __name__ == "__main__":
     if "glob" in context:
         glob_strs = context["glob"]
         globs = [item.strip() for item in glob_strs.split(',')]
+        print("Got the following globs: %s" % str(globs))
     # getting the script
-    wget_script(query,globs)
+    wget_script(query, globs)
     if emails=="unused":
 	make_product(rule_name, query)
     else:

--- a/wget.py
+++ b/wget.py
@@ -183,7 +183,7 @@ def glob_filter(names,pattern):
     import fnmatch
     files = []
     for pat in pattern:
-        matching = fnmatch.filter(names, pat)
+        matching = fnmatch.filter(names, "*" + pat)
         files.extend(matching)
     #unique list
     retfiles_set = set(files)

--- a/wget.py
+++ b/wget.py
@@ -16,7 +16,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger("hysds")
 
 
-def wget_script(dataset=None):
+def wget_script(dataset=None, glob_list=None):
     """Return wget script."""
 
     # query
@@ -56,7 +56,7 @@ def wget_script(dataset=None):
     scroll_id = scan_result['_scroll_id']
 
     # stream output a page at a time for better performance and lower memory footprint
-    def stream_wget(scroll_id):
+    def stream_wget(scroll_id, glob_list=None):
         #formatted_source = format_source(source)
         yield '#!/bin/bash\n#\n' + \
               '# query:\n#\n' + \
@@ -92,6 +92,8 @@ def wget_script(dataset=None):
                                 cut_dirs = 6
                 if '.s3-website' in url or 'amazonaws.com' in url:
                         files = get_s3_files(url)
+                        if glob_list:
+                            files = glob_filter(files, glob_list)
                         for file in files:
                                 yield 'echo "downloading  %s"\n' % file
                                 if 's1a_ifg' in url:
@@ -177,6 +179,16 @@ def make_product(rule_name, query):
     with open("{0}/{0}.dataset.json".format(name), "w") as fp:
         json.dump({"id": name, "version": "v0.1"}, fp)
 
+def glob_filter(names,pattern):
+    import fnmatch
+    files = []
+    for pat in pattern:
+        matching = fnmatch.filter(names, pat)
+        files.extend(matching)
+    #unique list
+    retfiles_set = set(files)
+    return list(retfiles_set)
+
 if __name__ == "__main__":
     '''
     Main program of wget_script
@@ -186,9 +198,21 @@ if __name__ == "__main__":
     query = json.loads(sys.argv[1]) 
     emails = sys.argv[2]
     rule_name = sys.argv[3]
-  
+
+    # get the glob
+    try:
+        context_file = '_context.json'
+        with open(context_file, 'r') as fin:
+            context = json.load(fin)
+    except:
+        raise Exception('unable to parse _context.json from work directory')
+
+    globs = None
+    if "glob" in context:
+        glob_strs = context["glob"]
+        globs = [item.strip() for item in glob_strs.split(',')]
     # getting the script
-    wget_script(query)
+    wget_script(query,globs)
     if emails=="unused":
 	make_product(rule_name, query)
     else:


### PR DESCRIPTION
Added a field for user to define an exclude glob to exclude files for download.
(kinda like rsync but still different)
From now users can define:
`include_glob`  and `exclude_glob` 
^ both are comma-separated list of globs(wildcards) to include and exclude files. 
Sequence:
1.) Job will create a list of files in `include_glob` first. 
2.) From the list of files in (1), job will remove files that matches `exclude_glob`

[Test logs](https://gist.github.com/shitong01/85193f64ee161af1c0785c1859f3a57c)