### PR TITLE
Add exclude glob option in wget job

### DIFF
--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -26,7 +26,7 @@
       "from": "submitter",
       "default": "*tiles*",
       "optional": true,
-      "placeholder": "(Optional) A comma seperated list of globs to exclude from included list",
+      "placeholder": "(Optional) A comma seperated list of globs to exclude from included list"
     },
     {
       "name": "name",

--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -14,10 +14,18 @@
       "from": "submitter"
     },
     {
-      "name": "glob",
+      "name": "include_glob",
       "type": "text",
       "from": "submitter",
+      "default": "*final*",
       "placeholder": "A comma seperated list of globs to download"
+    },
+    {
+      "name": "exclude_glob",
+      "type": "text",
+      "from": "submitter",
+      "default": "*tiles*",
+      "placeholder": "A comma seperated list of globs to exclude from included list"
     },
     {
       "name": "name",

--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -25,7 +25,8 @@
       "type": "text",
       "from": "submitter",
       "default": "*tiles*",
-      "placeholder": "A comma seperated list of globs to exclude from included list"
+      "optional": true,
+      "placeholder": "(Optional) A comma seperated list of globs to exclude from included list",
     },
     {
       "name": "name",

--- a/docker/hysds-io.json.lw-tosca-wget-glob
+++ b/docker/hysds-io.json.lw-tosca-wget-glob
@@ -17,7 +17,6 @@
       "name": "glob",
       "type": "text",
       "from": "submitter",
-      "default": "*fn*_logra2a1*.tif,*logamp*.tif,*.dem*,*msk.tif",
       "placeholder": "A comma seperated list of globs to download"
     },
     {

--- a/docker/job-spec.json.lw-tosca-wget-glob
+++ b/docker/job-spec.json.lw-tosca-wget-glob
@@ -19,7 +19,11 @@
       "destination": "positional"
     },
     {
-      "name": "glob",
+      "name": "include_glob",
+      "destination": "context"
+    },
+    {
+      "name": "exclude_glob",
       "destination": "context"
     }
    ]

--- a/wget.py
+++ b/wget.py
@@ -114,6 +114,7 @@ def wget_script(dataset=None, glob_dict=None):
                         if 's1a_ifg' in url:
                             yield "%s --cut-dirs=%d %s\n" % (wget_cmd, cut_dirs, file)
                         else:
+                            yield "%s --cut-dirs=%d %s\n" % (wget_cmd, cut_dirs, file)
                 if 'aria2-dav.jpl.nasa.gov' in url:
                     yield 'echo "downloading  %s"\n' % url
                     yield "%s --cut-dirs=%d %s/\n" % (wget_cmd_password, (cut_dirs+1), url)

--- a/wget.py
+++ b/wget.py
@@ -213,8 +213,6 @@ def glob_filter(names, glob_dict):
             files.extend(matching)
         print("Got the following files to include: %s" % str(files))
 
-
-    # TODO: continue working from here, we need to find a way to esclude from the current file list
     if exclude_csv:
         pattern_list_exc = [item.strip() for item in exclude_csv.split(',')]
 

--- a/wget.py
+++ b/wget.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger("hysds")
 
 
-def wget_script(dataset=None, glob_list=None):
+def wget_script(dataset=None, glob_dict=None):
     """Return wget script."""
 
     # query
@@ -68,7 +68,7 @@ def wget_script(dataset=None, glob_list=None):
     scroll_id = scan_result['_scroll_id']
 
     # stream output a page at a time for better performance and lower memory footprint
-    def stream_wget(scroll_id, glob_list=None):
+    def stream_wget(scroll_id, glob_dict=None):
         #formatted_source = format_source(source)
         yield '#!/bin/bash\n#\n' + \
               '# query:\n#\n' + \
@@ -107,14 +107,13 @@ def wget_script(dataset=None, glob_list=None):
                         cut_dirs = 6
                 if '.s3-website' in url or 'amazonaws.com' in url:
                     files = get_s3_files(url)
-                    if glob_list:
-                        files = glob_filter(files, glob_list)
+                    if glob_dict:
+                        files = glob_filter(files, glob_dict)
                     for file in files:
                         yield 'echo "downloading  %s"\n' % file
                         if 's1a_ifg' in url:
                             yield "%s --cut-dirs=%d %s\n" % (wget_cmd, cut_dirs, file)
                         else:
-                            yield "%s --cut-dirs=%d %s\n" % (wget_cmd, cut_dirs, file)
                 if 'aria2-dav.jpl.nasa.gov' in url:
                     yield 'echo "downloading  %s"\n' % url
                     yield "%s --cut-dirs=%d %s/\n" % (wget_cmd_password, (cut_dirs+1), url)
@@ -128,7 +127,7 @@ def wget_script(dataset=None, glob_list=None):
 
     # malarout: interate over each line of stream_wget response, and write to a file which is later attached to the email.
     with open('wget_script.sh','w') as f:
-        for i in stream_wget(scroll_id, glob_list):
+        for i in stream_wget(scroll_id, glob_dict):
                 f.write(i)
 
     # for gzip compressed use file extension .tar.gz and modifier "w:gz"
@@ -199,16 +198,40 @@ def make_product(rule_name, query):
     with open("{0}/{0}.dataset.json".format(name), "w") as fp:
         json.dump({"id": name, "version": "v0.1"}, fp)
 
-def glob_filter(names,pattern):
+def glob_filter(names, glob_dict):
     import fnmatch
     files = []
-    for pat in pattern:
-        matching = fnmatch.filter(names, "*" + pat)
-        files.extend(matching)
+    files_exclude = []
+    include_csv = glob_dict.get("include", None)
+    exclude_csv = glob_dict.get("exclude", None)
+
+    if include_csv:
+        pattern_list = [item.strip() for item in include_csv.split(',')]
+
+        for pat in pattern_list:
+            matching = fnmatch.filter(names, "*" + pat)
+            files.extend(matching)
+        print("Got the following files to include: %s" % str(files))
+
+
+    # TODO: continue working from here, we need to find a way to esclude from the current file list
+    if exclude_csv:
+        pattern_list_exc = [item.strip() for item in exclude_csv.split(',')]
+
+
+        for pat in pattern_list_exc:
+            matching = fnmatch.filter(names, "*" + pat)
+            files_exclude.extend(matching)
+
+        files_exclude = list(set(files_exclude))
+        print("Got the following files to exclude: %s" % str(files_exclude))
+
     #unique list
-    retfiles_set = set(files)
+    files_final = [x for x in files if x not in files_exclude]
+    retfiles_set = set(files_final)
     print("Got the following files: %s" % str(retfiles_set))
-    return list(retfiles_set)
+    return list(files_final)
+
 
 if __name__ == "__main__":
     '''
@@ -228,15 +251,15 @@ if __name__ == "__main__":
     except:
         raise Exception('unable to parse _context.json from work directory')
 
-    globs = None
-    if "glob" in context:
-        glob_strs = context["glob"]
-        globs = [item.strip() for item in glob_strs.split(',')]
-        print("Got the following globs: %s" % str(globs))
+    glob_dict = None
+    if "include_glob" in context and "exclude_glob" in context:
+        glob_dict = {"include":context["include_glob"], "exclude": context["exclude_glob"]}
+
     # getting the script
-    wget_script(query, globs)
-    if emails == "unused":
-        make_product(rule_name, query)
+
+    wget_script(query, glob_dict)
+    if emails=="unused":
+	make_product(rule_name, query)
     else:
         # now email the query
         email(query, emails, rule_name)


### PR DESCRIPTION
Similar to: https://github.com/earthobservatory/lightweight-jobs/pull/2

------------------------

Added a field for user to define an exclude glob to exclude files for download.
(kinda like rsync but still different)
From now users can define:
`include_glob`  and `exclude_glob` 
^ both are comma-separated list of globs(wildcards) to include and exclude files. 
Sequence:
1.) Job will create a list of files in `include_glob` first. 
2.) From the list of files in (1), job will remove files that matches `exclude_glob`

[Test logs](https://gist.github.com/shitong01/85193f64ee161af1c0785c1859f3a57c)