### PR TITLE
HC-149: set LD_LIBRARY_PATH

### DIFF
--- a/aws_get.sh
+++ b/aws_get.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $HOME/verdi/bin/activate
+source ~/.bash_profile
 
 BASE_PATH=$(dirname "${BASH_SOURCE}")
 

--- a/notify_by_email.sh
+++ b/notify_by_email.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $HOME/verdi/bin/activate
+source ~/.bash_profile
 
 BASE_PATH=$(dirname "${BASH_SOURCE}")
 

--- a/purge.sh
+++ b/purge.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $HOME/verdi/bin/activate
+source ~/.bash_profile
 
 BASE_PATH=$(dirname "${BASH_SOURCE}")
 

--- a/retry.sh
+++ b/retry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $HOME/verdi/bin/activate
+source ~/.bash_profile
 
 BASE_PATH=$(dirname "${BASH_SOURCE}")
 

--- a/wget.sh
+++ b/wget.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $HOME/verdi/bin/activate
+source ~/.bash_profile
 
 BASE_PATH=$(dirname "${BASH_SOURCE}")
 


### PR DESCRIPTION
The python lxml library needs LD_LIBRARY_PATH defined pointing to conda lib path. WIthout it, the following error occurs:
```
from lxml.etree import XMLParser, parse, tostring
ImportError: /lib64/libstdc++.so.6: version `CXXABI_1.3.8' not found (required by /opt/conda/lib/python3.7/site-packages/lxml/../../.././libicui18n.so.58)
```