### PR TITLE
HC-205: improve job revocation mechanism and bug fixes

### DIFF
--- a/purge.py
+++ b/purge.py
@@ -5,6 +5,9 @@ import osaka.main
 from hysds.celery import app
 from hysds_commons.elasticsearch_utils import ElasticsearchUtility
 
+from utils import revoke
+
+
 LOG_FILE_NAME = 'purge.log'
 logging.basicConfig(filename=LOG_FILE_NAME, filemode='a', level=logging.DEBUG)
 logger = logging
@@ -73,7 +76,7 @@ def purge_products(query, component, operation):
             if state in ["RETRY", "STARTED"] or (state == "PENDING" and not purge):
                 if not purge:
                     logger.info('Revoking %s\n', uuid)
-                    app.control.revoke(uuid, terminate=True)
+                    revoke(uuid, state)
                 else:
                     logger.info('Cannot remove active job %s\n', uuid)
                 continue
@@ -84,7 +87,7 @@ def purge_products(query, component, operation):
             # Safety net to revoke job if in PENDING state
             if state == "PENDING":
                 logger.info('Revoking %s\n', uuid)
-                app.control.revoke(uuid, terminate=True)
+                revoke(uuid, state)
 
             # Both associated task and job from ES
             logger.info('Removing document from index %s for %s', index, payload_id)

--- a/retry.py
+++ b/retry.py
@@ -92,7 +92,7 @@ def resubmit_jobs(context):
             doc = doc["hits"]["hits"][0]
 
             job_json = doc["_source"]["job"]
-            task_id = result["_source"]["uuid"]
+            task_id = doc["_source"]["uuid"]
             index = doc["_index"]
             _id = doc["_id"]
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,35 @@
+#!/bin/env python
+import backoff
+from redis import BlockingConnectionPool, StrictRedis, RedisError
+
+from hysds.celery import app
+
+
+REVOKED_TASK_POOL = None
+REVOKED_TASK_TMPL = "hysds-revoked-task-%s"
+
+
+def set_redis_revoked_task_pool():
+    """Set redis connection pool for worker status."""
+
+    global REVOKED_TASK_POOL
+    if REVOKED_TASK_POOL is None:
+        REVOKED_TASK_POOL = BlockingConnectionPool.from_url(
+            app.conf.REDIS_JOB_STATUS_URL)
+
+
+@backoff.on_exception(backoff.expo,
+                      RedisError,
+                      max_tries=10,
+                      max_value=64)
+def revoke(task_id, state):
+    """Revoke task."""
+
+    # revoke task
+    app.control.revoke(task_id, terminate=True)
+
+    # record revoke
+    r = StrictRedis(connection_pool=REVOKED_TASK_POOL)
+    r.setex(REVOKED_TASK_TMPL % task_id,
+            app.conf.HYSDS_JOB_STATUS_EXPIRES,
+            state)

--- a/utils.py
+++ b/utils.py
@@ -25,11 +25,15 @@ def set_redis_revoked_task_pool():
 def revoke(task_id, state):
     """Revoke task."""
 
-    # revoke task
-    app.control.revoke(task_id, terminate=True)
+    # set redis pool
+    set_redis_revoked_task_pool()
+    global REVOKED_TASK_POOL
 
-    # record revoke
+    # record revoked task
     r = StrictRedis(connection_pool=REVOKED_TASK_POOL)
     r.setex(REVOKED_TASK_TMPL % task_id,
             app.conf.HYSDS_JOB_STATUS_EXPIRES,
             state)
+
+    # revoke task
+    app.control.revoke(task_id, terminate=True)


### PR DESCRIPTION
The following PR addresses the following issues:
- propagation of revoked tasks in the presence of the `--without-mingle` celery worker option
  - upon any call to revoke a celery task (within `purge.py` and `retry.py`), an entry is recorded in mozart's redis so that job workers that fire up after the celery broadcast can detect it and revoke it itself
- improve performance of `retry.py` by removing randomized sleeps and using exponential backoff instead
- fix bug in `retry.py` where the wrong parameter (job_id) was being passed to the `revoke()` function; the celery task id (task_id) is now correctly being passed in and revoked