### PR TITLE
HC-282: add purge.sh wrapper and disable python bytecode writing

### DIFF
--- a/aws_get.sh
+++ b/aws_get.sh
@@ -3,6 +3,7 @@
 source ~/.bash_profile
 
 BASE_PATH=$(dirname "${BASH_SOURCE}")
+export PYTHONDONTWRITEBYTECODE=1
 
 # check args
 if [ "$#" -eq 3 ]; then

--- a/docker/job-spec.json.lw-mozart-purge
+++ b/docker/job-spec.json.lw-mozart-purge
@@ -1,6 +1,6 @@
 {
   "required_queues":["system-jobs-queue"],
-  "command":"python /home/ops/lightweight-jobs/purge.py",
+  "command":"/home/ops/lightweight-jobs/purge.sh",
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,

--- a/docker/job-spec.json.lw-tosca-purge
+++ b/docker/job-spec.json.lw-tosca-purge
@@ -1,6 +1,6 @@
 {
   "required_queues":["system-jobs-queue"],
-  "command":"python /home/ops/lightweight-jobs/purge.py",
+  "command":"/home/ops/lightweight-jobs/purge.sh",
   "imported_worker_files":{
     "$HOME/.aws":"/home/ops/.aws",
     "$HOME/.azure": "/home/ops/.azure"

--- a/notify_by_email.sh
+++ b/notify_by_email.sh
@@ -3,6 +3,7 @@
 source ~/.bash_profile
 
 BASE_PATH=$(dirname "${BASH_SOURCE}")
+export PYTHONDONTWRITEBYTECODE=1
 
 # send email
 echo "##########################################" 1>&2

--- a/purge.sh
+++ b/purge.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+BASE_PATH=$(dirname "${BASH_SOURCE}")
+BASE_PATH=$(cd "${BASE_PATH}"; pwd)
+
+# source PGE env
+export PYTHONPATH=$BASE_PATH:$PYTHONPATH
+export PATH=$BASE_PATH:$PATH
+export PYTHONDONTWRITEBYTECODE=1
+
+# source environment
+source $HOME/verdi/bin/activate
+
+echo "##########################################" 1>&2
+echo -n "Running purge.py: " 1>&2
+date 1>&2
+python $BASE_PATH/purge.py
+STATUS=$?
+echo -n "Finished running purge.py: " 1>&2
+date 1>&2
+if [ $STATUS -ne 0 ]; then
+  echo "Failed to run purge.py" 1>&2
+  cat purge.log 1>&2
+  exit $STATUS
+fi

--- a/retry.sh
+++ b/retry.sh
@@ -3,6 +3,7 @@
 source ~/.bash_profile
 
 BASE_PATH=$(dirname "${BASH_SOURCE}")
+export PYTHONDONTWRITEBYTECODE=1
 
 # retry job
 echo "##########################################" 1>&2

--- a/wget.sh
+++ b/wget.sh
@@ -3,6 +3,7 @@
 source ~/.bash_profile
 
 BASE_PATH=$(dirname "${BASH_SOURCE}")
+export PYTHONDONTWRITEBYTECODE=1
 
 # check args
 if [ "$#" -eq 3 ]; then


### PR DESCRIPTION
This PR encapsulates the call to the `purge.py` script in a wrapper shell script `purge.sh` to ensure that `PYTHONDONTWRITEBYTECODE` is set so that no `__pycache__` directory is created. Additionally, it sets that environment variable in the other wrapper shell scripts.