### PR TITLE
need to close the multiprocessing pool

### DIFF
--- a/purge.py
+++ b/purge.py
@@ -86,6 +86,7 @@ def purge_products(query, component, operation, delete_from_obj_store=True):
             p.map(delete_from_object_store, results)  # deleting objects from storage (s3, etc.)
         else:
             logger.info("skip purging datasets from object store. delete_from_object_store=False")
+        p.close()
 
         dataset_purge_stats = {}
         deleted_docs_count = 0


### PR DESCRIPTION
best practice to close the multiprocessing pool: https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.close
> Close the [Process](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process) object, releasing all resources associated with it. [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError) is raised if the underlying process is still running. Once [close()](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.close) returns successfully, most other methods and attributes of the [Process](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process) object will raise [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError).