### PR TITLE
HC-482: Make User Rule Job evaluation more targeted

### DIFF
--- a/retry.py
+++ b/retry.py
@@ -35,7 +35,7 @@ def query_es(job_id):
             }
         }
     }
-    return mozart_es.search(index=STATUS_ALIAS, body=query_json)
+    return mozart_es.search(index="job_status-current", body=query_json)
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64)


### PR DESCRIPTION
related PR(s):
- https://github.com/hysds/hysds/pull/177

Change(s):
- using `job-status_current` alias in `retry.py`

for `purge.py` would we can use the `job_status-current` alias but users wouldn't be able to purge tasks, workers and events

