### PR TITLE
hotfix: query job_status-current alias to only query job_status-* indices when purging jobs

### DIFF
--- a/purge.py
+++ b/purge.py
@@ -54,7 +54,7 @@ def purge_products(query, component, operation, delete_from_obj_store=True):
 
     if component == "mozart" or component == "figaro":
         es = get_mozart_es()
-        es_index = app.conf["STATUS_ALIAS"]
+        es_index = "job_status-current"
         _source = ["uuid", "payload_id"]
     else:  # "tosca"
         es = get_grq_es()
@@ -145,7 +145,7 @@ def purge_products(query, component, operation, delete_from_obj_store=True):
                 logger.info('Revoking %s\n', uuid)
                 revoke(uuid, state)
 
-            # Both associated task and job from ES
+            # Delete job from ES
             logger.info('Removing document from index %s for %s', index, payload_id)
             es.delete_by_id(index=index, id=payload_id, ignore=404)
             logger.info('Removed %s from index: %s', payload_id, index)


### PR DESCRIPTION
Currently the query is run against `job_status` which is aliased to job_status, task_status, worker_status, and event_status indices. When document results are returned from indices other than job_status and worker_status, the job will fail as it assumes certain parameters exist in the JSON payload, `payload_id`. This hotfix PR addresses this issue by only running the query against the `job_status-current` alias which is only aliased to job_status-* indices.