### PR TITLE
HC-550: Update job retry to allow specifying new time limits and a new job queue

### DIFF
--- a/docker/hysds-io.json.lw-mozart-retry
+++ b/docker/hysds-io.json.lw-mozart-retry
@@ -30,21 +30,21 @@
     },
     {
       "name": "soft_time_limit",
-      "placeholder": "specify a new soft time limit for the job being retried"
+      "placeholder": "specify a new soft time limit for the job being retried",
       "type": "number",
       "from": "submitter",
       "optional": true
     },
     {
       "name": "time_limit",
-      "placeholder": "specify a new time limit for the job being retried"
+      "placeholder": "specify a new time limit for the job being retried",
       "type": "number",
       "from": "submitter",
       "optional": true
     },
     {
       "name": "job_queue",
-      "placeholder": "specify a new job queue for the job being retried"
+      "placeholder": "specify a new job queue for the job being retried",
       "type": "text",
       "from": "submitter",
       "optional": true

--- a/docker/hysds-io.json.lw-mozart-retry
+++ b/docker/hysds-io.json.lw-mozart-retry
@@ -27,6 +27,27 @@
       ],
       "default": "0",
       "lambda": "lambda x: int(x)"
+    },
+    {
+      "name": "soft_time_limit",
+      "placeholder": "specify a new soft time limit for the job being retried"
+      "type": "number",
+      "from": "submitter",
+      "optional": true
+    },
+    {
+      "name": "time_limit",
+      "placeholder": "specify a new time limit for the job being retried"
+      "type": "number",
+      "from": "submitter",
+      "optional": true
+    },
+    {
+      "name": "job_queue",
+      "placeholder": "specify a new job queue for the job being retried"
+      "type": "text",
+      "from": "submitter",
+      "optional": true
     }
   ]
 }

--- a/docker/job-spec.json.lw-mozart-retry
+++ b/docker/job-spec.json.lw-mozart-retry
@@ -18,6 +18,18 @@
     {
       "name": "job_priority_increment",
       "destination": "context"
+    },
+    {
+      "name": "soft_time_limit",
+      "destination": "context"
+    },
+    {
+      "name": "time_limit",
+      "destination": "context"
+    },
+    {
+      "name": "job_queue",
+      "destination": "context"
     }
   ]
 }

--- a/retry.py
+++ b/retry.py
@@ -145,18 +145,6 @@ def resubmit_jobs(context):
             # delete old job status
             delete_by_id(index, _id)
 
-            # log queued status
-            job_status_json = {
-                'uuid': new_task_id,
-                'job_id': job_id,
-                'payload_id': job_json['job_info']['job_payload']['payload_task_id'],
-                'status': 'job-queued',
-                'job': job_json
-            }
-            log_job_status(job_status_json)
-
-            # submit job
-
             # check if new queues, soft time limit, and time limit values were set
             new_job_queue = context.get("job_queue", "")
             if new_job_queue:
@@ -173,6 +161,17 @@ def resubmit_jobs(context):
                 print(f"new time limit specified. Setting new time limit to {int(new_time_limit)}")
                 job_json['job_info']['time_limit'] = int(new_time_limit)
 
+            # log queued status
+            job_status_json = {
+                'uuid': new_task_id,
+                'job_id': job_id,
+                'payload_id': job_json['job_info']['job_payload']['payload_task_id'],
+                'status': 'job-queued',
+                'job': job_json
+            }
+            log_job_status(job_status_json)
+
+            # submit job
             run_job.apply_async((job_json,), queue=job_json['job_info']['job_queue'],
                                 time_limit=job_json['job_info']['time_limit'],
                                 soft_time_limit=job_json['job_info']['soft_time_limit'],

--- a/retry.py
+++ b/retry.py
@@ -156,8 +156,24 @@ def resubmit_jobs(context):
             log_job_status(job_status_json)
 
             # submit job
-            queue = job_json['job_info']['job_queue']
-            run_job.apply_async((job_json,), queue=queue,
+
+            # check if new queues, soft time limit, and time limit values were set
+            new_job_queue = context.get("job_queue", "")
+            if new_job_queue:
+                print(f"new job queue specified. Sending retry job to {new_job_queue}")
+                job_json['job_info']['job_queue'] = new_job_queue
+
+            new_soft_time_limit = context.get("soft_time_limit", "")
+            if new_soft_time_limit:
+                print(f"new soft time limit specified. Setting new soft time limit to {new_soft_time_limit}")
+                job_json['job_info']['soft_time_limit'] = int(new_soft_time_limit)
+
+            new_time_limit = context.get("time_limit", "")
+            if new_time_limit:
+                print(f"new time limit specified. Setting new time limit to {new_time_limit}")
+                job_json['job_info']['time_limit'] = int(new_time_limit)
+
+            run_job.apply_async((job_json,), queue=job_json['job_info']['job_queue'],
                                 time_limit=job_json['job_info']['time_limit'],
                                 soft_time_limit=job_json['job_info']['soft_time_limit'],
                                 priority=job_json['priority'],

--- a/retry.py
+++ b/retry.py
@@ -165,12 +165,12 @@ def resubmit_jobs(context):
 
             new_soft_time_limit = context.get("soft_time_limit", "")
             if new_soft_time_limit:
-                print(f"new soft time limit specified. Setting new soft time limit to {new_soft_time_limit}")
+                print(f"new soft time limit specified. Setting new soft time limit to {int(new_soft_time_limit)}")
                 job_json['job_info']['soft_time_limit'] = int(new_soft_time_limit)
 
             new_time_limit = context.get("time_limit", "")
             if new_time_limit:
-                print(f"new time limit specified. Setting new time limit to {new_time_limit}")
+                print(f"new time limit specified. Setting new time limit to {int(new_time_limit)}")
                 job_json['job_info']['time_limit'] = int(new_time_limit)
 
             run_job.apply_async((job_json,), queue=job_json['job_info']['job_queue'],


### PR DESCRIPTION
This PR updates the retry job such that it will now allow the setting of new time limits and a new job queue if desired. If left blank, the retry job will just use the original values specified in the job to be retried. 

Regarding the job queue, it unfortunately can't be a list of available queues since that is project specific. Therefore, for now, this job parameter just accepts a string value.

See comments in https://hysds-core.atlassian.net/browse/HC-550 to see how this was tested