### PR TITLE
HC-546: Update retry job to move failed job back to job_status index if retried

### DIFF
--- a/retry.py
+++ b/retry.py
@@ -145,6 +145,11 @@ def resubmit_jobs(context):
             # delete old job status
             delete_by_id(index, _id)
 
+            # Before re-queueing, check to see if the job was under the job_failed index. If so, need to
+            # move it back to job_status
+            if index.startswith("job_failed"):
+                job_json['job_info']['index'] = job_json['job_info']['index'].replace("job_failed", "job_status")
+
             # log queued status
             job_status_json = {
                 'uuid': new_task_id,

--- a/retry.py
+++ b/retry.py
@@ -148,7 +148,8 @@ def resubmit_jobs(context):
             # Before re-queueing, check to see if the job was under the job_failed index. If so, need to
             # move it back to job_status
             if index.startswith("job_failed"):
-                job_json['job_info']['index'] = job_json['job_info']['index'].replace("job_failed", "job_status")
+                current_time = datetime.utcnow()
+                job_json['job_info']['index'] = f"job_status-{current_time.strftime('%Y.%m.%d')}"
 
             # log queued status
             job_status_json = {


### PR DESCRIPTION
This PR is in conjunction with the following PRs:
- hysds: https://github.com/hysds/hysds/pull/193
- sdscli: https://github.com/sdskit/sdscli/pull/109

The retry job was updated such that if a failed job, which now will reside in a new `job_failed` index, is going to get retried, it will get moved back to the job_status index.

**Testing**
See comments in https://hysds-core.atlassian.net/browse/HC-546