### PR TITLE
HC-556: Update retry and purge jobs to delete all possible instances of a job across multiple indices

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,13 @@ MAINTAINER malarout "Namrata.Malarout@jpl.nasa.gov"
 LABEL description="Lightweight System Jobs"
 
 # provision lightweight-jobs PGE
+
+# softlink /home/ops
+RUN ln -s /root /home/ops
+
+# Make sure $HOME is set when we run this container
+ENV HOME=/home/ops
+
 USER ops
 COPY . /home/ops/lightweight-jobs
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,9 @@ LABEL description="Lightweight System Jobs"
 
 # provision lightweight-jobs PGE
 
+# create ops user and group
+RUN useradd -M -u 10005 ops
+
 # softlink /home/ops
 RUN ln -s /root /home/ops
 

--- a/purge.py
+++ b/purge.py
@@ -162,8 +162,7 @@ if __name__ == "__main__":
 
     query_obj = context['query']
     try:
-        if isinstance(query_obj, str):
-            query_obj = json.loads(query_obj)
+        query_obj = json.loads(query_obj)
     except TypeError as e:
         logger.warning(e)
 

--- a/purge.py
+++ b/purge.py
@@ -162,7 +162,8 @@ if __name__ == "__main__":
 
     query_obj = context['query']
     try:
-        query_obj = json.loads(query_obj)
+        if isinstance(query_obj, str):
+            query_obj = json.loads(query_obj)
     except TypeError as e:
         logger.warning(e)
 

--- a/retry.py
+++ b/retry.py
@@ -60,7 +60,7 @@ def ensure_job_indexed(id, status):
     print("ensure_job_indexed: %s" % json.dumps(query_json))
     count = mozart_es.get_count(index=JOB_STATUS_CURRENT, body=query_json)
     if count == 0:
-        raise RuntimeError(f"Failed to find indexed job with job_id={job_id} and status={status}")
+        raise RuntimeError(f"Failed to find indexed job with payload_id={id} and status={status}")
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64)

--- a/retry.py
+++ b/retry.py
@@ -42,8 +42,10 @@ def query_es(job_id):
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64)
 def delete_by_id(index, _id):
-    mozart_es.delete_by_id(index=index, id=_id)
-
+    results = mozart_es.search_by_id(index=index, id=_id, return_all=True)
+    for result in results:
+        print(f"Deleting job {result['_id']} in {result['_index']}")
+        mozart_es.delete_by_id(index=result['_index'], id=result['_id'])
 
 def get_new_job_priority(old_priority, increment_by, new_priority):
     if increment_by is not None:

--- a/retry.py
+++ b/retry.py
@@ -57,8 +57,8 @@ def ensure_job_indexed(id, status):
         "query": {
             "bool": {
                 "must": [
-                    {"term": {"payload_id.keyword": id}},
-                    {"term": {"status.keyword": status}}
+                    {"match": {"payload_id": id}},
+                    {"match": {"status": status}}
                 ]
             }
         }

--- a/retry.py
+++ b/retry.py
@@ -21,7 +21,8 @@ STATUS_ALIAS = app.conf["STATUS_ALIAS"]
 JOB_STATUS_CURRENT = "job_status-current"
 
 LOG_FILE_NAME = 'purge.log'
-logging.basicConfig(filename=LOG_FILE_NAME, filemode='a', level=logging.INFO)
+log_format = "[%(asctime)s: %(levelname)s/%(funcName)s] %(message)s"
+logging.basicConfig(format=log_format, filename=LOG_FILE_NAME, filemode='a', level=logging.INFO)
 logger = logging
 
 mozart_es = get_mozart_es()
@@ -48,7 +49,7 @@ def query_es(job_id):
 
 
 @backoff.on_exception(
-    backoff.expo, Exception, max_tries=3, max_value=10
+    backoff.expo, Exception, max_tries=4, max_value=16
 )
 def ensure_job_indexed(id, status):
     """Ensure job is indexed."""

--- a/retry.py
+++ b/retry.py
@@ -43,7 +43,7 @@ def query_es(job_id):
 
 
 @backoff.on_exception(
-    backoff.expo, Exception, max_tries=10, max_value=64
+    backoff.expo, Exception, max_tries=3, max_value=10
 )
 def ensure_job_indexed(id, status):
     """Ensure job is indexed."""
@@ -161,7 +161,7 @@ def resubmit_jobs(context):
             job_id = job_json['job_id']
             try:
                 revoke(task_id, state)
-                print("revoked original job: %s (%s)" % (job_id, task_id))
+                print("revoked original job: %s (%s) state=%s" % (job_id, task_id, state))
                 time.sleep(7)  # sleep 7 seconds to allow ES documents to be indexed
                 # wait for confirmation of job-revoked
                 ensure_job_indexed(_id, status="job-revoked")

--- a/retry.py
+++ b/retry.py
@@ -218,7 +218,7 @@ def resubmit_jobs(context):
                                 soft_time_limit=job_json['job_info']['soft_time_limit'],
                                 priority=job_json['priority'],
                                 task_id=new_task_id)
-            print(f"re-submitted job: ")
+            print(f"re-submitted job_id={job_id}, task_id={new_task_id}")
         except Exception as ex:
             print("[ERROR] Exception occurred {0}:{1} {2}".format(type(ex), ex, traceback.format_exc()),
                   file=sys.stderr)

--- a/retry.py
+++ b/retry.py
@@ -4,6 +4,7 @@ import json
 import traceback
 import backoff
 import time
+import logging
 
 from datetime import datetime
 from celery import uuid
@@ -18,6 +19,10 @@ from utils import revoke
 
 STATUS_ALIAS = app.conf["STATUS_ALIAS"]
 JOB_STATUS_CURRENT = "job_status-current"
+
+LOG_FILE_NAME = 'purge.log'
+logging.basicConfig(filename=LOG_FILE_NAME, filemode='a', level=logging.INFO)
+logger = logging
 
 mozart_es = get_mozart_es()
 
@@ -57,7 +62,7 @@ def ensure_job_indexed(id, status):
             }
         }
     }
-    print("ensure_job_indexed: %s" % json.dumps(query_json))
+    logger.info("ensure_job_indexed: %s" % json.dumps(query_json))
     count = mozart_es.get_count(index=JOB_STATUS_CURRENT, body=query_json)
     if count == 0:
         raise RuntimeError(f"Failed to find indexed job with payload_id={id} and status={status}")
@@ -67,7 +72,7 @@ def ensure_job_indexed(id, status):
 def delete_by_id(index, _id):
     results = mozart_es.search_by_id(index=index, id=_id, return_all=True)
     for result in results:
-        print(f"Deleting job {result['_id']} in {result['_index']}")
+        logger.info(f"Deleting job {result['_id']} in {result['_index']}")
         mozart_es.delete_by_id(index=result['_index'], id=result['_id'])
 
 
@@ -75,8 +80,8 @@ def get_new_job_priority(old_priority, increment_by, new_priority):
     if increment_by is not None:
         priority = int(old_priority) + int(increment_by)
         if priority == 0 or priority == 9:
-            print("Not applying {} on previous priority of {}")
-            print("Priority must be between 0 and 8".format(increment_by, old_priority))
+            logger.info("Not applying {} on previous priority of {}")
+            logger.info("Priority must be between 0 and 8".format(increment_by, old_priority))
             priority = int(old_priority)
     else:
         priority = int(new_priority)
@@ -105,11 +110,11 @@ def resubmit_jobs(context):
         retry_job_ids = [context['retry_job_id']]
 
     for job_id in retry_job_ids:
-        print("Validating retry job: {}".format(job_id))
+        logger.info("Validating retry job: {}".format(job_id))
         try:
             doc = query_es(job_id)
             if doc['hits']['total']['value'] == 0:
-                print('job id %s not found in Elasticsearch. Continuing.' % job_id)
+                logger.warning('job id %s not found in Elasticsearch. Continuing.' % job_id)
                 continue
             doc = doc["hits"]["hits"][0]
 
@@ -119,12 +124,12 @@ def resubmit_jobs(context):
             _id = doc["_id"]
 
             if not index.startswith("job"):
-                print("Cannot retry a worker: %s" % _id)
+                logger.error("Cannot retry a worker: %s" % _id)
                 continue
 
             # don't retry a retry
             if job_json['type'].startswith('job-lw-mozart-retry'):
-                print("Cannot retry retry job %s. Skipping" % job_id)
+                logger.error("Cannot retry retry job %s. Skipping" % job_id)
                 continue
 
             # check retry_remaining_count
@@ -132,8 +137,8 @@ def resubmit_jobs(context):
                 if job_json['retry_count'] < retry_count_max:
                     job_json['retry_count'] = int(job_json['retry_count']) + 1
                 else:
-                    print("For job {}, retry_count now is {}, retry_count_max limit of {} reached. Cannot retry again."
-                          .format(job_id, job_json['retry_count'], retry_count_max))
+                    logger.error("For job {}, retry_count now is {}, retry_count_max limit of {} reached. Cannot retry again."
+                                 .format(job_id, job_json['retry_count'], retry_count_max))
                     continue
             else:
                 job_json['retry_count'] = 1
@@ -161,13 +166,13 @@ def resubmit_jobs(context):
             job_id = job_json['job_id']
             try:
                 revoke(task_id, state)
-                print("revoked original job: %s (%s) state=%s" % (job_id, task_id, state))
+                logger.info("revoked original job: %s (%s) state=%s" % (job_id, task_id, state))
                 time.sleep(7)  # sleep 7 seconds to allow ES documents to be indexed
                 # wait for confirmation of job-revoked
                 ensure_job_indexed(_id, status="job-revoked")
             except:
-                print("Got error issuing revoke on job %s (%s): %s" % (job_id, task_id, traceback.format_exc()))
-                print("Continuing.")
+                logger.error("Got error issuing revoke on job %s (%s): %s" % (job_id, task_id, traceback.format_exc()))
+                logger.error("Continuing.")
 
             # generate celery task id
             new_task_id = uuid()
@@ -183,17 +188,17 @@ def resubmit_jobs(context):
             # check if new queues, soft time limit, and time limit values were set
             new_job_queue = context.get("job_queue", "")
             if new_job_queue:
-                print(f"new job queue specified. Sending retry job to {new_job_queue}")
+                logger.info(f"new job queue specified. Sending retry job to {new_job_queue}")
                 job_json['job_info']['job_queue'] = new_job_queue
 
             new_soft_time_limit = context.get("soft_time_limit", "")
             if new_soft_time_limit:
-                print(f"new soft time limit specified. Setting new soft time limit to {int(new_soft_time_limit)}")
+                logger.info(f"new soft time limit specified. Setting new soft time limit to {int(new_soft_time_limit)}")
                 job_json['job_info']['soft_time_limit'] = int(new_soft_time_limit)
 
             new_time_limit = context.get("time_limit", "")
             if new_time_limit:
-                print(f"new time limit specified. Setting new time limit to {int(new_time_limit)}")
+                logger.info(f"new time limit specified. Setting new time limit to {int(new_time_limit)}")
                 job_json['job_info']['time_limit'] = int(new_time_limit)
 
             # Before re-queueing, check to see if the job was under the job_failed index. If so, need to
@@ -218,10 +223,9 @@ def resubmit_jobs(context):
                                 soft_time_limit=job_json['job_info']['soft_time_limit'],
                                 priority=job_json['priority'],
                                 task_id=new_task_id)
-            print(f"re-submitted job_id={job_id}, payload_id={job_status_json['payload_id']}, task_id={new_task_id}")
+            logger.info(f"re-submitted job_id={job_id}, payload_id={job_status_json['payload_id']}, task_id={new_task_id}")
         except Exception as ex:
-            print("[ERROR] Exception occurred {0}:{1} {2}".format(type(ex), ex, traceback.format_exc()),
-                  file=sys.stderr)
+            logger.error("[ERROR] Exception occurred {0}:{1} {2}".format(type(ex), ex, traceback.format_exc()))
 
 
 if __name__ == "__main__":
@@ -230,4 +234,4 @@ if __name__ == "__main__":
     # if input_type == "job":
     resubmit_jobs(ctx)
     # else:
-    #     print("Cannot retry a task, worker or event.")
+    #     logger.info("Cannot retry a task, worker or event.")

--- a/retry.py
+++ b/retry.py
@@ -49,7 +49,7 @@ def query_es(job_id):
 
 
 @backoff.on_exception(
-    backoff.expo, Exception, max_tries=4, max_value=16
+    backoff.expo, Exception, max_tries=6, max_value=16
 )
 def ensure_job_indexed(id, status):
     """Ensure job is indexed."""
@@ -57,8 +57,8 @@ def ensure_job_indexed(id, status):
         "query": {
             "bool": {
                 "must": [
-                    {"match": {"payload_id": id}},
-                    {"match": {"status": status}}
+                    {"term": {"payload_id": id}},
+                    {"term": {"status": status}}
                 ]
             }
         }

--- a/retry.py
+++ b/retry.py
@@ -20,7 +20,7 @@ from utils import revoke
 STATUS_ALIAS = app.conf["STATUS_ALIAS"]
 JOB_STATUS_CURRENT = "job_status-current"
 
-LOG_FILE_NAME = 'purge.log'
+LOG_FILE_NAME = 'retry.log'
 log_format = "[%(asctime)s: %(levelname)s/%(funcName)s] %(message)s"
 logging.basicConfig(format=log_format, filename=LOG_FILE_NAME, filemode='a', level=logging.INFO)
 logger = logging


### PR DESCRIPTION
This PR is in conjunction with https://github.com/hysds/hysds/pull/195

When testing the fixing of the auto-retry feature, I ran into an issue where a job was appearing in multiple indices:

![image](https://github.com/user-attachments/assets/2a3bb8d5-ccc4-4bd6-a584-2d900338daab)

This comes about when a worker is spot terminated, so at the verdi level, a revoke signal is sent to stop the job while in parallel, at the job_worker level, the job is going to be declared as job-failed. So, depending on the timing of when these statuses come in, you may see a situation such as this.

In order to mitigate the confusion, at the retry and purge job levels, the retry and purge jobs will now make sure to query for the job_id across the `job_status-current` alias and prior to submitting a retry, it will make sure to delete each instance of that job, whether it's in job_status or job_failed.

See https://github.com/hysds/hysds/pull/195 for details on how this was tested

**Housekeeping Updates**

- Added logging instead of print statements so that we can log out the timing of the messages for better debugging and analysis in the future.
- Added softlinking to /home/ops in the Dockerfile build
