### PR TITLE
HC-572: Update purge job to ignore 404 errors when trying to delete documents

### DIFF
--- a/purge.py
+++ b/purge.py
@@ -151,7 +151,7 @@ def purge_products(query, component, operation, delete_from_obj_store=True):
             results = es.search_by_id(index=index, id=payload_id, return_all=True, ignore=404)
             for result in results:
                 logger.info('Removing document from index %s for %s', result['_id'], result['_index'])
-                es.delete_by_id(index=result['_index'], id=result['_id'])
+                es.delete_by_id(index=result['_index'], id=result['_id'], ignore=404)
                 logger.info('Removed %s from index: %s', result['_id'], result['_index'])
         logger.info('Finished.')
 


### PR DESCRIPTION
This fixes the issue where the purge job gets a 404 error when trying to delete a document. Currently, it will raise an error and prematurely exit out of the job. Updating the _delete_by_id_ function to ignore 404 errors allows the job to gracefully ignore that and continue on with the job