### PR TITLE
HC-530: Updates to support Data in Transit

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM hysds/pge-base:develop
+FROM hysds/pge-base:develop-dit
 
 MAINTAINER malarout "Namrata.Malarout@jpl.nasa.gov"
 LABEL description="Lightweight System Jobs"

--- a/docker/job-spec.json.lightweight-echo
+++ b/docker/job-spec.json.lightweight-echo
@@ -3,6 +3,9 @@
   "disk_usage":"1GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params" : [
     {
       "name": "echo_var",

--- a/docker/job-spec.json.lw-mozart-notify-by-email
+++ b/docker/job-spec.json.lw-mozart-notify-by-email
@@ -4,6 +4,9 @@
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params" : [
     {
       "name": "id",

--- a/docker/job-spec.json.lw-mozart-purge
+++ b/docker/job-spec.json.lw-mozart-purge
@@ -4,6 +4,9 @@
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params" : [
     {
       "name": "query",

--- a/docker/job-spec.json.lw-mozart-reprioritize
+++ b/docker/job-spec.json.lw-mozart-reprioritize
@@ -6,6 +6,9 @@
   "disk_usage": "3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params": [
     {
       "name": "retry_job_id",

--- a/docker/job-spec.json.lw-mozart-retry
+++ b/docker/job-spec.json.lw-mozart-retry
@@ -6,6 +6,9 @@
   "disk_usage": "3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params": [
     {
       "name": "retry_job_id",

--- a/docker/job-spec.json.lw-mozart-revoke
+++ b/docker/job-spec.json.lw-mozart-revoke
@@ -6,6 +6,9 @@
   "disk_usage": "3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params": [
     {
       "name": "query",

--- a/docker/job-spec.json.lw-tosca-aws_get
+++ b/docker/job-spec.json.lw-tosca-aws_get
@@ -5,6 +5,9 @@
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params" : [
     {
       "name": "query",

--- a/docker/job-spec.json.lw-tosca-notify-by-email
+++ b/docker/job-spec.json.lw-tosca-notify-by-email
@@ -4,6 +4,9 @@
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params" : [
     {
       "name": "id",

--- a/docker/job-spec.json.lw-tosca-purge
+++ b/docker/job-spec.json.lw-tosca-purge
@@ -8,6 +8,9 @@
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params" : [
     {
       "name": "query",

--- a/docker/job-spec.json.lw-tosca-wget
+++ b/docker/job-spec.json.lw-tosca-wget
@@ -5,6 +5,9 @@
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params" : [
     {
       "name": "query",

--- a/docker/job-spec.json.lw-tosca-wget-email
+++ b/docker/job-spec.json.lw-tosca-wget-email
@@ -5,6 +5,9 @@
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params" : [
     {
       "name": "query",

--- a/docker/job-spec.json.lw-tosca-wget-glob
+++ b/docker/job-spec.json.lw-tosca-wget-glob
@@ -5,6 +5,9 @@
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,
+  "imported_worker_files": {
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "params" : [
     {
       "name": "query",

--- a/docker/job-spec.json.lw-tosca-wget-product
+++ b/docker/job-spec.json.lw-tosca-wget-product
@@ -1,7 +1,10 @@
 {
   "required_queues":["system-jobs-queue"],
   "command":"/home/ops/lightweight-jobs/wget.sh",
-  "imported_worker_files":{"$HOME/.aws":"/home/ops/.aws"}, 
+  "imported_worker_files":{
+    "$HOME/.aws":"/home/ops/.aws",
+    "$HOME/.netrc-os": "/home/ops/.netrc-os"
+  },
   "disk_usage":"3GB",
   "soft_time_limit": 86400,
   "time_limit": 86700,


### PR DESCRIPTION
- Updated all the job spec configuration files to mount in the new ~/.netrc-os file in order to support connecting to a DIT OpenSearch configuration