### PR TITLE
Use ES wrapper search method to handle closed indices (HC-600)

### DIFF
--- a/aws_get.py
+++ b/aws_get.py
@@ -19,7 +19,7 @@ def aws_get_script(dataset=None):
     grq_es = get_grq_es()
     index = app.conf["DATASET_ALIAS"]
     logger.debug(f"Dataset: {json.dumps(dataset, indent=2)}")
-    paged_result = grq_es.es.search(body=dataset, index=index, size=10, scroll="10m")
+    paged_result = grq_es.search(body=dataset, index=index, size=10, scroll="10m")
     logger.debug(f"Paged Result: {json.dumps(paged_result, indent=2)}")
 
     scroll_ids = set()

--- a/wget.py
+++ b/wget.py
@@ -28,7 +28,7 @@ def wget_script(dataset=None, glob_dict=None):
     grq_es = get_grq_es()
     index = app.conf["DATASET_ALIAS"]
     logger.debug(f"Dataset: {json.dumps(dataset, indent=2)}")
-    paged_result = grq_es.es.search(body=dataset, index=index, size=100, scroll="10m")
+    paged_result = grq_es.search(body=dataset, index=index, size=100, scroll="10m")
     logger.debug(f"Paged Result: {json.dumps(paged_result, indent=2)}")
 
     scroll_ids = set()


### PR DESCRIPTION
## Summary

- Replace direct ES client calls with wrapper methods to leverage automatic closed index handling from hysds_commons
- `aws_get.py`: Change `grq_es.es.search()` to `grq_es.search()`
- `wget.py`: Change `grq_es.es.search()` to `grq_es.search()`

The `scroll()` and `clear_scroll()` calls remain unchanged as they operate on scroll IDs, not index patterns.

## Test plan

- [x] Verify aws_get job works correctly with wildcard index patterns
- [x] Verify wget job works correctly with wildcard index patterns
- [x] Test with closed indices in the `grq_*` pattern

## Dependencies

- Requires [hysds_commons PR #67](https://github.com/hysds/hysds_commons/pull/67) to be merged first

## Related

- Jira: [HC-600](https://hysds-core.atlassian.net/browse/HC-600)

[HC-600]: https://hysds-core.atlassian.net/browse/HC-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Closed-index-safe querying via ES wrapper**
> 
> - Replace `grq_es.es.search()` with `grq_es.search()` in `aws_get.py` and `wget.py` to use the wrapper’s automatic handling of closed indices
> - No other logic changes; existing `scroll()`/`clear_scroll()` calls remain as-is
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10cd467df62111a11c76ac0a9c307b8fc49cc62c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->