### PR TITLE
HC-633: Updated retry job to support faster user_rules processing

### DIFF
--- a/notify_by_email.py
+++ b/notify_by_email.py
@@ -6,6 +6,8 @@ import json
 import base64
 import socket
 
+import backoff
+
 from smtplib import SMTP
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -197,6 +199,23 @@ def get_facetview_link(link, _id, version=None):
     return "{}/?{}".format(link, query_string)
 
 
+@backoff.on_predicate(
+    backoff.expo, lambda r: r["hits"]["total"]["value"] == 0, max_tries=4, max_value=4
+)
+def search_until_visible(es, index, query):
+    """Look up the triggering doc, retrying while it isn't search-visible yet.
+
+    The user_rules trigger can fire before the ingested doc is searchable --
+    refresh lag, or a lagging replica since this lookup carries no shard
+    preference. Removing the fixed user_rules sleeps (HC-633) widens that
+    window, so an immediate lookup can miss and produce a metadata-less email.
+    Retry on empty results to let the write become visible, then give up
+    gracefully: the caller still sends the notification (minus the metadata
+    snippet) if the doc never appears, so slow indexing never drops the email.
+    """
+    return es.search(index=index, body=query)
+
+
 if __name__ == "__main__":
     path = "/".join(__file__.split("/")[0:-1])
     settings_file = os.path.join(path, "settings.json")
@@ -235,7 +254,7 @@ if __name__ == "__main__":
             }
         }
     }
-    result = es.search(index=index, body=query)  # can't use get_by_id on alias
+    result = search_until_visible(es, index, query)  # can't use get_by_id on alias
 
     if result["hits"]["total"]["value"] > 0:
         doc = result["hits"]["hits"][0]

--- a/retry.py
+++ b/retry.py
@@ -224,7 +224,7 @@ def resubmit_jobs(context):
             logger.error(f"[ERROR] Exception occurred {type(ex)}:{ex} {traceback.format_exc()}")
 
     if not_found_job_ids:
-        msg_details = "Jobs not found:\n"
+        msg_details = "Some jobs not found, so could not retry:\n"
         msg_details += json.dumps(not_found_job_ids, indent=2)
         logger.warning(msg_details)
         if len(retry_job_ids) == 1:

--- a/retry.py
+++ b/retry.py
@@ -70,7 +70,7 @@ def delete_by_id(index, _id):
     results = mozart_es.search_by_id(index=index, id=_id, return_all=True)
     for result in results:
         logger.info(f"Deleting job {result['_id']} in {result['_index']}")
-        mozart_es.delete_by_id(index=result['_index'], id=result['_id'])
+        mozart_es.delete_by_id(index=result['_index'], id=result['_id'], ignore=[404])
 
 
 def get_new_job_priority(old_priority, increment_by, new_priority):

--- a/retry.py
+++ b/retry.py
@@ -35,21 +35,20 @@ def read_context():
         return cxt
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64)
-def query_es(job_id):
-    query_json = {
-        "query": {
-            "bool": {
-                "must": [
-                    {"term": {"job.job_info.id": job_id}}
-                ]
-            }
-        }
-    }
-    return mozart_es.search(index=JOB_STATUS_CURRENT, body=query_json)
+class JobNotFoundError(Exception):
+    """The retry target job id has no status doc in OpenSearch."""
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=4, max_value=4)
+# Two retry budgets: the outer decorator retries a not-found result briefly
+# (HC-633: the faster user_rules trigger can fire before the just-written
+# status doc is search-visible), while the inner decorator keeps the long
+# transport retry so a transient OpenSearch outage surfaces as a retried
+# query, not a skipped job. JobNotFoundError is raised as a distinct type so
+# only the not-found signal is handled as "job not found" by the caller --
+# a ValueError from unrelated code must not be misreported as a missing job.
+@backoff.on_exception(backoff.expo, JobNotFoundError, max_tries=4, max_value=4)
+@backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64,
+                      giveup=lambda e: isinstance(e, JobNotFoundError))
 def query_es_required(job_id):
     query_json = {
         "query": {
@@ -62,29 +61,60 @@ def query_es_required(job_id):
     }
     result = mozart_es.search(index=JOB_STATUS_CURRENT, body=query_json)
     if result['hits']['total']['value'] == 0:
-        raise ValueError(f"job id {job_id} not found in OpenSearch")
+        raise JobNotFoundError(f"job id {job_id} not found in OpenSearch")
     return result
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64)
 def delete_by_id(index, _id):
-    results = mozart_es.search_by_id(index=index, id=_id, return_all=True)
+    # without ignore=[404], search_by_id raises ValueError on 0 hits (e.g. a
+    # concurrent retry already deleted the doc), which would churn through
+    # this backoff for minutes before failing the retry; an already-absent
+    # doc is a no-op here, so ask for the not-found sentinel and skip it
+    results = mozart_es.search_by_id(index=index, id=_id, return_all=True, ignore=[404])
     for result in results:
+        if result.get("found") is False:
+            logger.info(f"No {_id} doc found in {index}; nothing to delete.")
+            continue
         logger.info(f"Deleting job {result['_id']} in {result['_index']}")
         mozart_es.delete_by_id(index=result['_index'], id=result['_id'], ignore=[404])
 
 
 def _wait_for_lock_release(payload_id, task_id, timeout, max_interval):
-    """Poll the Redis job lock with exponential backoff until released or timeout is reached."""
+    """Poll the Redis job lock with exponential backoff until released or timeout is reached.
+
+    Returns "released" if the lock was released while polling, "force_released"
+    if the timeout hit with the revoked task confirmed stopped (its stale lock
+    is cleared before resubmit), or "held" if the timeout hit while the task
+    still appears to be running (the lock is left in place -- force-releasing
+    a live task's lock would let the resubmitted job run concurrently with the
+    original, the duplicate-execution race the lock exists to prevent; the
+    resubmitted job may fail lock acquisition until the task actually stops).
+    """
 
     temp_lock = JobLock(payload_id, task_id="revoke-wait", worker_hostname="mozart")
+    outcome = {"result": "held"}
 
     def _on_giveup(details):
-        logger.warning(
-            f"Lock for payload {payload_id} not released within "
-            f"{details['elapsed']:.1f}s. Force-releasing before resubmit."
-        )
-        temp_lock.force_release()
+        # revoke() failures are logged-and-continued by the caller, so the
+        # original task may still be alive and heartbeating its lock; only
+        # clear the lock once celery confirms the task reached a terminal
+        # state, otherwise leave it to the resubmitted job's own acquisition
+        state = app.AsyncResult(task_id).state
+        if state in ("SUCCESS", "FAILURE", "REVOKED"):
+            logger.warning(
+                f"Lock for payload {payload_id} not released within "
+                f"{details['elapsed']:.1f}s but task {task_id} is {state}. "
+                f"Force-releasing stale lock before resubmit."
+            )
+            temp_lock.force_release()
+            outcome["result"] = "force_released"
+        else:
+            logger.error(
+                f"Lock for payload {payload_id} not released within "
+                f"{details['elapsed']:.1f}s and task {task_id} is still {state}. "
+                f"Leaving lock in place to avoid duplicate execution."
+            )
 
     @backoff.on_predicate(
         backoff.expo,
@@ -105,10 +135,10 @@ def _wait_for_lock_release(payload_id, task_id, timeout, max_interval):
             logger.warning(f"Error polling lock metadata for payload {payload_id}: {e}")
         return False
 
-    result = _poll()
-    if result:
+    if _poll():
         logger.info(f"Lock for payload {payload_id} released, proceeding with resubmit")
-    return result
+        return "released"
+    return outcome["result"]
 
 
 def get_new_job_priority(old_priority, increment_by, new_priority):
@@ -145,7 +175,9 @@ def resubmit_jobs(context):
         retry_job_ids = [context['retry_job_id']]
 
     not_found_job_ids = []
-    revoke_timed_out = []
+    errored_job_ids = []
+    force_released_locks = []
+    locks_still_held = []
     info_msgs = []
     info_msg_details = ""
 
@@ -216,8 +248,11 @@ def resubmit_jobs(context):
             # before resubmitting to avoid the deduplication lock race condition
             if state == "STARTED":
                 payload_id = job_json['job_info']['job_payload']['payload_task_id']
-                if not _wait_for_lock_release(payload_id, task_id, revoke_wait_timeout, revoke_wait_max_interval):
-                    revoke_timed_out.append(f"payload_id: {payload_id} (task_id: {task_id})")
+                lock_outcome = _wait_for_lock_release(payload_id, task_id, revoke_wait_timeout, revoke_wait_max_interval)
+                if lock_outcome == "force_released":
+                    force_released_locks.append(f"payload_id: {payload_id} (task_id: {task_id})")
+                elif lock_outcome == "held":
+                    locks_still_held.append(f"payload_id: {payload_id} (task_id: {task_id})")
 
             # generate celery task id
             new_task_id = uuid()
@@ -269,16 +304,23 @@ def resubmit_jobs(context):
                                 priority=job_json['priority'],
                                 task_id=new_task_id)
             logger.info(f"re-submitted job_id={job_id}, payload_id={job_status_json['payload_id']}, task_id={new_task_id}")
-        except ValueError as ex:
+        except JobNotFoundError as ex:
             logger.warning(str(ex))
             not_found_job_ids.append(job_id)
         except Exception as ex:
             logger.error(f"[ERROR] Exception occurred {type(ex)}:{ex} {traceback.format_exc()}")
+            errored_job_ids.append(job_id)
 
-    if revoke_timed_out:
+    if force_released_locks:
         info_msgs.append("Revoke wait timed out")
-        info_msg_details += f"\n\nLock for these jobs did not release within {revoke_wait_timeout}s. Force-released before resubmission:\n"
-        for detail in revoke_timed_out:
+        info_msg_details += f"\n\nLock for these jobs did not release within {revoke_wait_timeout}s. The revoked task had stopped, so the stale lock was force-released before resubmission:\n"
+        for detail in force_released_locks:
+            info_msg_details += f"{detail}\n"
+
+    if locks_still_held:
+        info_msgs.append("Job lock still held at resubmit")
+        info_msg_details += f"\n\nThe original task for these jobs was still running {revoke_wait_timeout}s after revoke. Their locks were left in place to avoid duplicate execution, so the resubmitted job may fail with 'already running' until the task stops:\n"
+        for detail in locks_still_held:
             info_msg_details += f"{detail}\n"
 
     if not_found_job_ids and len(retry_job_ids) > 1:
@@ -288,11 +330,21 @@ def resubmit_jobs(context):
         info_msgs.append("Some retry jobs not found")
         info_msg_details += f"\n\n{not_found_details}"
 
+    if errored_job_ids and len(retry_job_ids) > 1:
+        errored_details = "Some jobs hit errors during resubmission; see tracebacks in the log:\n"
+        errored_details += json.dumps(errored_job_ids, indent=2)
+        logger.warning(errored_details)
+        info_msgs.append("Some retry jobs errored")
+        info_msg_details += f"\n\n{errored_details}"
+
     if info_msgs:
         create_info_message_files(msg=info_msgs, msg_details=info_msg_details)
 
-    if not_found_job_ids and len(retry_job_ids) == 1:
-        raise RuntimeError(f"job id {not_found_job_ids[0]} not found")
+    if len(retry_job_ids) == 1:
+        if not_found_job_ids:
+            raise RuntimeError(f"job id {not_found_job_ids[0]} not found")
+        if errored_job_ids:
+            raise RuntimeError(f"failed to resubmit job id {errored_job_ids[0]}; see traceback in the log")
 
 
 if __name__ == "__main__":

--- a/retry.py
+++ b/retry.py
@@ -10,6 +10,7 @@ from celery import uuid
 
 from hysds.celery import app
 from hysds.es_util import get_mozart_es
+from hysds.lock import JobLock
 from hysds.orchestrator import run_job
 from hysds.log_utils import log_job_status
 from hysds.utils import datetime_iso_naive
@@ -73,6 +74,43 @@ def delete_by_id(index, _id):
         mozart_es.delete_by_id(index=result['_index'], id=result['_id'], ignore=[404])
 
 
+def _wait_for_lock_release(payload_id, task_id, timeout, max_interval):
+    """Poll the Redis job lock with exponential backoff until released or timeout is reached."""
+
+    temp_lock = JobLock(payload_id, task_id="revoke-wait", worker_hostname="mozart")
+
+    def _on_giveup(details):
+        logger.warning(
+            f"Lock for payload {payload_id} not released within "
+            f"{details['elapsed']:.1f}s. Force-releasing before resubmit."
+        )
+        temp_lock.force_release()
+
+    @backoff.on_predicate(
+        backoff.expo,
+        max_time=timeout,
+        max_value=max_interval,
+        on_backoff=lambda details: logger.info(
+            f"Lock for payload {payload_id} still held by {task_id}, retrying in {details['wait']:.1f}s "
+            f"(elapsed: {details['elapsed']:.1f}s)"
+        ),
+        on_giveup=_on_giveup,
+    )
+    def _poll():
+        try:
+            metadata = temp_lock.get_lock_metadata()
+            if not metadata or metadata.get("task_id") != task_id:
+                return True
+        except Exception as e:
+            logger.warning(f"Error polling lock metadata for payload {payload_id}: {e}")
+        return False
+
+    result = _poll()
+    if result:
+        logger.info(f"Lock for payload {payload_id} released, proceeding with resubmit")
+    return result
+
+
 def get_new_job_priority(old_priority, increment_by, new_priority):
     if increment_by is not None:
         priority = int(old_priority) + int(increment_by)
@@ -107,6 +145,13 @@ def resubmit_jobs(context):
         retry_job_ids = [context['retry_job_id']]
 
     not_found_job_ids = []
+    revoke_timed_out = []
+    info_msgs = []
+    info_msg_details = ""
+
+    heartbeat_interval = app.conf.get("JOB_LOCK_HEARTBEAT_INTERVAL", 30)
+    revoke_wait_timeout = heartbeat_interval * app.conf.get("JOB_LOCK_STALE_CHECK_RETRIES", 3) + app.conf.get("JOB_LOCK_REDELIVERY_BUFFER_TIME", 10)
+    revoke_wait_max_interval = heartbeat_interval // 2
 
     for job_id in retry_job_ids:
         logger.info(f"Validating retry job: {job_id}")
@@ -167,6 +212,13 @@ def resubmit_jobs(context):
                 logger.error("Got error issuing revoke on job {} ({}): {}".format(job_id, task_id, traceback.format_exc()))
                 logger.error("Continuing.")
 
+            # if the task was actively running, wait for confirmation it has stopped
+            # before resubmitting to avoid the deduplication lock race condition
+            if state == "STARTED":
+                payload_id = job_json['job_info']['job_payload']['payload_task_id']
+                if not _wait_for_lock_release(payload_id, task_id, revoke_wait_timeout, revoke_wait_max_interval):
+                    revoke_timed_out.append(f"payload_id: {payload_id} (task_id: {task_id})")
+
             # generate celery task id
             new_task_id = uuid()
             job_json['task_id'] = new_task_id
@@ -223,14 +275,24 @@ def resubmit_jobs(context):
         except Exception as ex:
             logger.error(f"[ERROR] Exception occurred {type(ex)}:{ex} {traceback.format_exc()}")
 
-    if not_found_job_ids:
-        msg_details = "Some jobs not found, so could not retry:\n"
-        msg_details += json.dumps(not_found_job_ids, indent=2)
-        logger.warning(msg_details)
-        if len(retry_job_ids) == 1:
-            raise RuntimeError(f"job id {not_found_job_ids[0]} not found")
-        else:
-            create_info_message_files(msg_details=msg_details)
+    if revoke_timed_out:
+        info_msgs.append("Revoke wait timed out")
+        info_msg_details += f"\n\nLock for these jobs did not release within {revoke_wait_timeout}s. Force-released before resubmission:\n"
+        for detail in revoke_timed_out:
+            info_msg_details += f"{detail}\n"
+
+    if not_found_job_ids and len(retry_job_ids) > 1:
+        not_found_details = "Some jobs not found, so could not retry:\n"
+        not_found_details += json.dumps(not_found_job_ids, indent=2)
+        logger.warning(not_found_details)
+        info_msgs.append("Some retry jobs not found")
+        info_msg_details += f"\n\n{not_found_details}"
+
+    if info_msgs:
+        create_info_message_files(msg=info_msgs, msg_details=info_msg_details)
+
+    if not_found_job_ids and len(retry_job_ids) == 1:
+        raise RuntimeError(f"job id {not_found_job_ids[0]} not found")
 
 
 if __name__ == "__main__":

--- a/retry.py
+++ b/retry.py
@@ -14,7 +14,7 @@ from hysds.orchestrator import run_job
 from hysds.log_utils import log_job_status
 from hysds.utils import datetime_iso_naive
 
-from utils import revoke
+from utils import revoke, create_info_message_files
 
 
 STATUS_ALIAS = app.conf["STATUS_ALIAS"]
@@ -46,6 +46,23 @@ def query_es(job_id):
         }
     }
     return mozart_es.search(index=JOB_STATUS_CURRENT, body=query_json)
+
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=4, max_value=4)
+def query_es_required(job_id):
+    query_json = {
+        "query": {
+            "bool": {
+                "must": [
+                    {"term": {"job.job_info.id": job_id}}
+                ]
+            }
+        }
+    }
+    result = mozart_es.search(index=JOB_STATUS_CURRENT, body=query_json)
+    if result['hits']['total']['value'] == 0:
+        raise ValueError(f"job id {job_id} not found in OpenSearch")
+    return result
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64)
@@ -89,13 +106,12 @@ def resubmit_jobs(context):
     else:
         retry_job_ids = [context['retry_job_id']]
 
+    not_found_job_ids = []
+
     for job_id in retry_job_ids:
         logger.info(f"Validating retry job: {job_id}")
         try:
-            doc = query_es(job_id)
-            if doc['hits']['total']['value'] == 0:
-                logger.warning('job id %s not found in Elasticsearch. Continuing.' % job_id)
-                continue
+            doc = query_es_required(job_id)
             doc = doc["hits"]["hits"][0]
 
             job_json = doc["_source"]["job"]
@@ -201,8 +217,20 @@ def resubmit_jobs(context):
                                 priority=job_json['priority'],
                                 task_id=new_task_id)
             logger.info(f"re-submitted job_id={job_id}, payload_id={job_status_json['payload_id']}, task_id={new_task_id}")
+        except ValueError as ex:
+            logger.warning(str(ex))
+            not_found_job_ids.append(job_id)
         except Exception as ex:
             logger.error(f"[ERROR] Exception occurred {type(ex)}:{ex} {traceback.format_exc()}")
+
+    if not_found_job_ids:
+        msg_details = "Jobs not found:\n"
+        msg_details += json.dumps(not_found_job_ids, indent=2)
+        logger.warning(msg_details)
+        if len(retry_job_ids) == 1:
+            raise RuntimeError(f"job id {not_found_job_ids[0]} not found")
+        else:
+            create_info_message_files(msg_details=msg_details)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Due to the improvements in the user_rules processing to speed up performance:
- https://github.com/hysds/hysds/pull/219
- https://github.com/hysds/hysds_commons/pull/71

This brought up race conditions when automatic retry jobs get triggered in the system. Specifically, the improvements made are the following:
- Added exponential backoff when querying to see if a specific job exists in OpenSearch. Previously, we would just silently continue on with processing, but due to the removal of sleeps, a recently ingested dataset or job record may not be yet searchable, so we need to give it some time for it to fully appear in OpenSearch, especially in a multi-node set up.
- After revoking a job prior to re-submission, if the task was actively running, wait for confirmation it has stopped before resubmitting to avoid the deduplication lock race condition

In terms of testing, the HC-633 updates were run through SWOT's automated load test to verify the expected behavior.

---

**Additional fix — `notify_by_email.py`:**

`notify_by_email.py` is the other lightweight job commonly auto-triggered by user_rules, and it had the same read-after-write exposure. Its by-`_id` metadata lookup carried no shard preference and no retry, so when the email job runs before the ingested doc is search-visible (refresh lag / lagging replica) it returns 0 hits and the email is sent missing its metadata snippet, `metadata.json` attachment, browse images, and FacetView link. Removing the sleeps makes that window more likely to be hit.

Wrapped the lookup in `search_until_visible()` — a `backoff.on_predicate` retry-while-0-hits with the same 4-try / 4s budget as the retry job's `query_es_required`. Unlike the retry path it gives up gracefully (returns the empty result rather than raising), so the notification is still sent — only degraded — if the doc never becomes searchable.

Audited the remaining lightweight jobs; no others need changes: revoke/purge (`purge.py`) only kill tasks (no resubmit → no dedup-lock race) and are operator-on-demand (no searchability race), reprioritize already runs `retry.py`, and aws_get/wget are on-demand dataset downloads.
