### PR TITLE
HC-633: harden retry.py error handling and lock force-release

### DIFF
--- a/retry.py
+++ b/retry.py
@@ -35,21 +35,20 @@ def read_context():
         return cxt
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64)
-def query_es(job_id):
-    query_json = {
-        "query": {
-            "bool": {
-                "must": [
-                    {"term": {"job.job_info.id": job_id}}
-                ]
-            }
-        }
-    }
-    return mozart_es.search(index=JOB_STATUS_CURRENT, body=query_json)
+class JobNotFoundError(Exception):
+    """The retry target job id has no status doc in OpenSearch."""
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=4, max_value=4)
+# Two retry budgets: the outer decorator retries a not-found result briefly
+# (HC-633: the faster user_rules trigger can fire before the just-written
+# status doc is search-visible), while the inner decorator keeps the long
+# transport retry so a transient OpenSearch outage surfaces as a retried
+# query, not a skipped job. JobNotFoundError is raised as a distinct type so
+# only the not-found signal is handled as "job not found" by the caller --
+# a ValueError from unrelated code must not be misreported as a missing job.
+@backoff.on_exception(backoff.expo, JobNotFoundError, max_tries=4, max_value=4)
+@backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64,
+                      giveup=lambda e: isinstance(e, JobNotFoundError))
 def query_es_required(job_id):
     query_json = {
         "query": {
@@ -62,29 +61,60 @@ def query_es_required(job_id):
     }
     result = mozart_es.search(index=JOB_STATUS_CURRENT, body=query_json)
     if result['hits']['total']['value'] == 0:
-        raise ValueError(f"job id {job_id} not found in OpenSearch")
+        raise JobNotFoundError(f"job id {job_id} not found in OpenSearch")
     return result
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=10, max_value=64)
 def delete_by_id(index, _id):
-    results = mozart_es.search_by_id(index=index, id=_id, return_all=True)
+    # without ignore=[404], search_by_id raises ValueError on 0 hits (e.g. a
+    # concurrent retry already deleted the doc), which would churn through
+    # this backoff for minutes before failing the retry; an already-absent
+    # doc is a no-op here, so ask for the not-found sentinel and skip it
+    results = mozart_es.search_by_id(index=index, id=_id, return_all=True, ignore=[404])
     for result in results:
+        if result.get("found") is False:
+            logger.info(f"No {_id} doc found in {index}; nothing to delete.")
+            continue
         logger.info(f"Deleting job {result['_id']} in {result['_index']}")
         mozart_es.delete_by_id(index=result['_index'], id=result['_id'], ignore=[404])
 
 
 def _wait_for_lock_release(payload_id, task_id, timeout, max_interval):
-    """Poll the Redis job lock with exponential backoff until released or timeout is reached."""
+    """Poll the Redis job lock with exponential backoff until released or timeout is reached.
+
+    Returns "released" if the lock was released while polling, "force_released"
+    if the timeout hit with the revoked task confirmed stopped (its stale lock
+    is cleared before resubmit), or "held" if the timeout hit while the task
+    still appears to be running (the lock is left in place -- force-releasing
+    a live task's lock would let the resubmitted job run concurrently with the
+    original, the duplicate-execution race the lock exists to prevent; the
+    resubmitted job may fail lock acquisition until the task actually stops).
+    """
 
     temp_lock = JobLock(payload_id, task_id="revoke-wait", worker_hostname="mozart")
+    outcome = {"result": "held"}
 
     def _on_giveup(details):
-        logger.warning(
-            f"Lock for payload {payload_id} not released within "
-            f"{details['elapsed']:.1f}s. Force-releasing before resubmit."
-        )
-        temp_lock.force_release()
+        # revoke() failures are logged-and-continued by the caller, so the
+        # original task may still be alive and heartbeating its lock; only
+        # clear the lock once celery confirms the task reached a terminal
+        # state, otherwise leave it to the resubmitted job's own acquisition
+        state = app.AsyncResult(task_id).state
+        if state in ("SUCCESS", "FAILURE", "REVOKED"):
+            logger.warning(
+                f"Lock for payload {payload_id} not released within "
+                f"{details['elapsed']:.1f}s but task {task_id} is {state}. "
+                f"Force-releasing stale lock before resubmit."
+            )
+            temp_lock.force_release()
+            outcome["result"] = "force_released"
+        else:
+            logger.error(
+                f"Lock for payload {payload_id} not released within "
+                f"{details['elapsed']:.1f}s and task {task_id} is still {state}. "
+                f"Leaving lock in place to avoid duplicate execution."
+            )
 
     @backoff.on_predicate(
         backoff.expo,
@@ -105,10 +135,10 @@ def _wait_for_lock_release(payload_id, task_id, timeout, max_interval):
             logger.warning(f"Error polling lock metadata for payload {payload_id}: {e}")
         return False
 
-    result = _poll()
-    if result:
+    if _poll():
         logger.info(f"Lock for payload {payload_id} released, proceeding with resubmit")
-    return result
+        return "released"
+    return outcome["result"]
 
 
 def get_new_job_priority(old_priority, increment_by, new_priority):
@@ -145,7 +175,9 @@ def resubmit_jobs(context):
         retry_job_ids = [context['retry_job_id']]
 
     not_found_job_ids = []
-    revoke_timed_out = []
+    errored_job_ids = []
+    force_released_locks = []
+    locks_still_held = []
     info_msgs = []
     info_msg_details = ""
 
@@ -216,8 +248,11 @@ def resubmit_jobs(context):
             # before resubmitting to avoid the deduplication lock race condition
             if state == "STARTED":
                 payload_id = job_json['job_info']['job_payload']['payload_task_id']
-                if not _wait_for_lock_release(payload_id, task_id, revoke_wait_timeout, revoke_wait_max_interval):
-                    revoke_timed_out.append(f"payload_id: {payload_id} (task_id: {task_id})")
+                lock_outcome = _wait_for_lock_release(payload_id, task_id, revoke_wait_timeout, revoke_wait_max_interval)
+                if lock_outcome == "force_released":
+                    force_released_locks.append(f"payload_id: {payload_id} (task_id: {task_id})")
+                elif lock_outcome == "held":
+                    locks_still_held.append(f"payload_id: {payload_id} (task_id: {task_id})")
 
             # generate celery task id
             new_task_id = uuid()
@@ -269,16 +304,23 @@ def resubmit_jobs(context):
                                 priority=job_json['priority'],
                                 task_id=new_task_id)
             logger.info(f"re-submitted job_id={job_id}, payload_id={job_status_json['payload_id']}, task_id={new_task_id}")
-        except ValueError as ex:
+        except JobNotFoundError as ex:
             logger.warning(str(ex))
             not_found_job_ids.append(job_id)
         except Exception as ex:
             logger.error(f"[ERROR] Exception occurred {type(ex)}:{ex} {traceback.format_exc()}")
+            errored_job_ids.append(job_id)
 
-    if revoke_timed_out:
+    if force_released_locks:
         info_msgs.append("Revoke wait timed out")
-        info_msg_details += f"\n\nLock for these jobs did not release within {revoke_wait_timeout}s. Force-released before resubmission:\n"
-        for detail in revoke_timed_out:
+        info_msg_details += f"\n\nLock for these jobs did not release within {revoke_wait_timeout}s. The revoked task had stopped, so the stale lock was force-released before resubmission:\n"
+        for detail in force_released_locks:
+            info_msg_details += f"{detail}\n"
+
+    if locks_still_held:
+        info_msgs.append("Job lock still held at resubmit")
+        info_msg_details += f"\n\nThe original task for these jobs was still running {revoke_wait_timeout}s after revoke. Their locks were left in place to avoid duplicate execution, so the resubmitted job may fail with 'already running' until the task stops:\n"
+        for detail in locks_still_held:
             info_msg_details += f"{detail}\n"
 
     if not_found_job_ids and len(retry_job_ids) > 1:
@@ -288,11 +330,21 @@ def resubmit_jobs(context):
         info_msgs.append("Some retry jobs not found")
         info_msg_details += f"\n\n{not_found_details}"
 
+    if errored_job_ids and len(retry_job_ids) > 1:
+        errored_details = "Some jobs hit errors during resubmission; see tracebacks in the log:\n"
+        errored_details += json.dumps(errored_job_ids, indent=2)
+        logger.warning(errored_details)
+        info_msgs.append("Some retry jobs errored")
+        info_msg_details += f"\n\n{errored_details}"
+
     if info_msgs:
         create_info_message_files(msg=info_msgs, msg_details=info_msg_details)
 
-    if not_found_job_ids and len(retry_job_ids) == 1:
-        raise RuntimeError(f"job id {not_found_job_ids[0]} not found")
+    if len(retry_job_ids) == 1:
+        if not_found_job_ids:
+            raise RuntimeError(f"job id {not_found_job_ids[0]} not found")
+        if errored_job_ids:
+            raise RuntimeError(f"failed to resubmit job id {errored_job_ids[0]}; see traceback in the log")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose
Follow-up hardening of the HC-633 retry.py updates, from the code review on the ticket. Merges into the `HC-633` branch (#43) so it rides the same PR into develop.

## Changes

**1. Dedicated not-found signal (`JobNotFoundError`)**
`query_es_required` raised a bare `ValueError`, and `resubmit_jobs` caught `except ValueError` around the whole loop body — so any unrelated `ValueError` (`int(soft_time_limit)` / `int(time_limit)`, the `int()` conversions in `get_new_job_priority`, or `search_by_id`'s 0-hit `ValueError`) was misreported as *"job id not found"*. Worse, those fire **after** the original job was already revoked and its status doc deleted, so the job was destroyed, not resubmitted, and misdiagnosed. Now only the real not-found signal takes that path; anything else lands in the generic handler and is reported (see 4).

**2. Two retry budgets on the job lookup**
Replacing `query_es` (10-try/max-64s) with `query_es_required` (4-try/max-4s) kept the visibility race covered but dropped the transport resilience: a ~30s OpenSearch blip during a bulk retry exhausted the ~7s budget and the job was silently skipped. Stacked backoff decorators now give:
- not-found → 4 tries / max 4s (unchanged — the HC-633 refresh-lag window), then reported as not found;
- any other exception (connection/transport) → 10 tries / max 64s (the pre-existing budget), then reported as errored.

Verified in isolation: not-found = exactly 4 search attempts; transient outage recovers through the long budget; sustained outage propagates instead of being swallowed. The now-dead `query_es` is removed.

**3. `delete_by_id`: `ignore=[404]` on the call that actually raises**
`ignore=[404]` was on the `delete_by_id` ES call, but it's the preceding `search_by_id` that raises `ValueError` on 0 hits — an already-deleted status doc (e.g. a concurrent auto-retry got there first) churned the 10-try/64s backoff for ~4 minutes and then fed the misclassification in (1). `search_by_id` now gets `ignore=[404]` and the `found: False` sentinel is skipped, making the absent-doc case a logged no-op.

**4. Force-release only for confirmed-stopped tasks**
`revoke()` failures are logged-and-continued, so the original task can still be alive and heartbeating its lock when the revoke-wait times out. Unconditionally force-releasing then let the resubmitted job acquire a fresh lock while the original was still running — concurrent duplicate execution (double-publishing) with `dedup=False`, which is the exact race the lock exists to prevent. The giveup handler now checks `app.AsyncResult(task_id).state`:
- terminal (`SUCCESS` / `FAILURE` / `REVOKED`) → force-release the stale lock and resubmit, as before;
- still alive → leave the lock in place; the resubmitted job's own lock acquisition decides (worst case a visible `already running` failure until the task actually stops — the pre-HC-633 behavior for this edge).

The two timeout outcomes are reported as separate info messages ("Revoke wait timed out" force-released vs "Job lock still held at resubmit").

**5. Errored jobs are surfaced instead of silently skipped**
A new `errored_job_ids` bucket mirrors the not-found reporting: bulk retries emit a "Some retry jobs errored" info message with the ids; a **single-job** retry whose resubmission failed now fails the retry task (RuntimeError) instead of exiting `task-succeeded` having resubmitted nothing — the silent-swallow failure mode from the SWOT load test.

## Judgment calls to weigh in review
- (5) changes single-job semantics: a retry that hits a sustained ES outage now shows as a failed task rather than a clean no-op. That seems like the point, but it is a visible behavior change.
- (4) trades "always resubmittable after the wait timeout" for "never duplicate-execute": if the celery result backend misreports a dead task as `STARTED`, the lock stays until JobLock's own stale-lock detection or TTL clears it.

## Testing
- `python -m py_compile retry.py` clean.
- Stacked-backoff budgets exercised standalone (not-found = 4 attempts; transient ES failure recovers via the 10×64 path; sustained failure propagates as the transport error).
- Not yet run through the SWOT automated load test — that's the meaningful validation for (4)/(5) and worth a pass before #43 merges.
